### PR TITLE
feat: #009 build cli.js entry point

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,7 +11,7 @@
     "plugins": ["node"],
     "parserOptions": {
       "ecmaVersion": "latest",
-      "sourceType": "commonjs"
+      "sourceType": "module"
     },
     "rules": {
       "no-unused-vars": "warn",

--- a/cli.js
+++ b/cli.js
@@ -1,2 +1,72 @@
 #!/usr/bin/env node
-console.log('Scaffy is alive! 🚀');
+
+import { Command } from 'commander';
+import chalk from 'chalk';
+import figlet from 'figlet';
+import ora from 'ora';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const { version } = require('./package.json');
+
+const program = new Command();
+
+// ─── Banner ───────────────────────────────────────────
+const showBanner = () => {
+  console.log(
+    chalk.cyan(
+      figlet.textSync('Scaffy', {
+        font: 'Big',
+        horizontalLayout: 'default',
+      })
+    )
+  );
+  console.log(chalk.gray('  One command. Any framework. Ready to code.\n'));
+};
+
+// ─── Program Setup ────────────────────────────────────
+program
+  .name('scaffy')
+  .description('One command. Any framework. Ready to code.')
+  .version(version, '-v, --version', 'Show current version');
+
+// ─── Default Command (Interactive Mode) ───────────────
+program
+  .argument('[framework]', 'Framework to scaffold directly')
+  .action(async framework => {
+    showBanner();
+
+    if (framework) {
+      console.log(chalk.cyan(`\n🔍 Looking for framework: ${framework}...\n`));
+      // TODO: Issue #008 — registry lookup comes here
+      console.log(chalk.yellow(`⚠️  Registry not built yet. Coming soon!`));
+      return;
+    }
+
+    // TODO: Issue #009 — interactive mode comes here
+    console.log(chalk.yellow(`⚠️  Interactive mode coming soon!`));
+  });
+
+// ─── List Command ─────────────────────────────────────
+program
+  .command('list')
+  .description('List all available frameworks')
+  .action(() => {
+    showBanner();
+    // TODO: Issue #008 — registry list comes here
+    console.log(chalk.yellow(`⚠️  Registry not built yet. Coming soon!`));
+  });
+
+// ─── Search Command ───────────────────────────────────
+program
+  .command('search <query>')
+  .description('Search for a framework')
+  .action(query => {
+    showBanner();
+    console.log(chalk.cyan(`\n🔍 Searching for: ${query}...\n`));
+    // TODO: Issue #008 — registry search comes here
+    console.log(chalk.yellow(`⚠️  Registry not built yet. Coming soon!`));
+  });
+
+// ─── Parse ────────────────────────────────────────────
+program.parse(process.argv);

--- a/core/tests/jest-setup.test.js
+++ b/core/tests/jest-setup.test.js
@@ -1,32 +1,29 @@
 describe('Jest Setup', () => {
-
-    test('Jest is working correctly', () => {
-      expect(true).toBe(true)
-    })
-  
-    test('Basic math works', () => {
-      expect(2 + 3).toBe(5)
-    })
-  
-    test('String operations work', () => {
-      expect('scaffy').toContain('scaff')
-    })
-  
-    test('Array operations work', () => {
-      const frameworks = ['laravel', 'nestjs', 'vuejs']
-      expect(frameworks).toHaveLength(3)
-      expect(frameworks).toContain('laravel')
-    })
-  
-    test('Object operations work', () => {
-      const plugin = {
-        name: 'Laravel',
-        language: 'php',
-        version: 'v11'
-      }
-      expect(plugin).toHaveProperty('name', 'Laravel')
-      expect(plugin).toHaveProperty('language', 'php')
-    })
-  
+  test('Jest is working correctly', () => {
+    expect(true).toBe(true);
   });
-  
+
+  test('Basic math works', () => {
+    expect(2 + 3).toBe(5);
+  });
+
+  test('String operations work', () => {
+    expect('scaffy').toContain('scaff');
+  });
+
+  test('Array operations work', () => {
+    const frameworks = ['laravel', 'nestjs', 'vuejs'];
+    expect(frameworks).toHaveLength(3);
+    expect(frameworks).toContain('laravel');
+  });
+
+  test('Object operations work', () => {
+    const plugin = {
+      name: 'Laravel',
+      language: 'php',
+      version: 'v11',
+    };
+    expect(plugin).toHaveProperty('name', 'Laravel');
+    expect(plugin).toHaveProperty('language', 'php');
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   // Test environment
   testEnvironment: 'node',
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "chalk": "^5.3.0",
-        "commander": "^11.0.0",
-        "figlet": "^1.7.0",
-        "inquirer": "^9.2.0",
+        "chalk": "^5.6.2",
+        "commander": "^11.1.0",
+        "figlet": "^1.10.0",
+        "inquirer": "^9.3.8",
         "ora": "^7.0.1",
         "semver": "^7.5.4"
       },

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "scaffy",
+  "type": "module",
   "version": "0.1.0",
   "description": "One command. Any framework. Ready to code.",
   "author": "Md Tanvir Hossen <tanvirhossen112@gmail.com>",
@@ -32,10 +33,10 @@
     "prepare": "husky install"
   },
   "dependencies": {
-    "chalk": "^5.3.0",
-    "commander": "^11.0.0",
-    "figlet": "^1.7.0",
-    "inquirer": "^9.2.0",
+    "chalk": "^5.6.2",
+    "commander": "^11.1.0",
+    "figlet": "^1.10.0",
+    "inquirer": "^9.3.8",
     "ora": "^7.0.1",
     "semver": "^7.5.4"
   },


### PR DESCRIPTION
## 📋 Description
Builds the main CLI entry point with beautiful
ASCII banner, commander.js routing, and placeholder
commands for list, search, and direct framework call.

## 🔗 Related Issue
Closes #9 

## 🔄 Type of Change
- [x] feat (new feature)

## ✅ Acceptance Criteria
- [x] commander.js installed
- [x] chalk installed
- [x] figlet installed
- [x] ora installed
- [x] inquirer installed
- [x] scaffy --help works
- [x] scaffy --version shows 0.1.0
- [x] Beautiful banner displays
- [x] scaffy <framework> works as direct call

## 🧪 How To Test
1. Pull this branch
2. Run node cli.js
3. Run node cli.js --help
4. Run node cli.js --version
5. Run node cli.js list
6. Run node cli.js search laravel
7. Verify banner shows on all commands

## 📊 Checklist
- [x] Branch is up to date with develop
- [x] Linked to correct milestone