### PR TITLE
feat: #011 build registry.js plugin loader

### DIFF
--- a/core/registry.js
+++ b/core/registry.js
@@ -1,2 +1,128 @@
-// TODO: Coming in Sprint 1
-module.exports = {};
+const path = require('path');
+const fs = require('fs');
+const chalk = require('chalk');
+
+const REGISTRY_PATH = path.join(__dirname, '..', 'registry');
+const INDEX_PATH = path.join(REGISTRY_PATH, 'index.json');
+
+const loadIndex = () => {
+  try {
+    const raw = fs.readFileSync(INDEX_PATH, 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+};
+
+const getFrameworks = () => {
+  const index = loadIndex();
+  if (!index) {
+    console.log(chalk.red('❌ Failed to load registry/index.json'));
+    return [];
+  }
+  return index.frameworks;
+};
+
+const findFramework = query => {
+  const q = query.toLowerCase().trim();
+
+  return (
+    getFrameworks().find(
+      f =>
+        f.name.toLowerCase() === q || f.alias.some(a => a.toLowerCase() === q)
+    ) || null
+  );
+};
+
+const searchFrameworks = query => {
+  const q = query.toLowerCase().trim();
+
+  return getFrameworks().filter(
+    f =>
+      f.name.toLowerCase().includes(q) ||
+      f.language.toLowerCase().includes(q) ||
+      f.alias.some(a => a.toLowerCase().includes(q))
+  );
+};
+
+const groupByLanguage = frameworks =>
+  frameworks.reduce(
+    (acc, f) => ({
+      ...acc,
+      [f.language]: [...(acc[f.language] || []), f],
+    }),
+    {}
+  );
+
+const validatePluginFiles = (pluginPath, version) => {
+  const versionPath = path.join(pluginPath, version);
+
+  const requiredFiles = [
+    { path: path.join(pluginPath, 'plugin.json'), name: 'plugin.json' },
+    { path: path.join(versionPath, 'questions.js'), name: 'questions.js' },
+    { path: path.join(versionPath, 'scaffold.js'), name: 'scaffold.js' },
+  ];
+
+  const missing = requiredFiles
+    .filter(f => !fs.existsSync(f.path))
+    .map(f => f.name);
+
+  return {
+    valid: missing.length === 0,
+    missing,
+  };
+};
+
+const loadPlugin = (framework, version) => {
+  const pluginPath = path.join(REGISTRY_PATH, framework.path);
+  const versionPath = path.join(pluginPath, version);
+
+  const { valid, missing } = validatePluginFiles(pluginPath, version);
+
+  if (!valid) {
+    throw new Error(
+      `Missing files for ${framework.name} ${version}: ` + missing.join(', ')
+    );
+  }
+
+  return {
+    meta: require(path.join(pluginPath, 'plugin.json')),
+    questions: require(path.join(versionPath, 'questions.js')),
+    scaffold: require(path.join(versionPath, 'scaffold.js')),
+  };
+};
+
+const formatFrameworkLine = f =>
+  chalk.white(`    • ${f.name}`) +
+  chalk.gray(` (${f.alias.join(', ')}) — latest: ${f.latest}`);
+
+const displayFrameworks = () => {
+  const frameworks = getFrameworks();
+
+  if (frameworks.length === 0) {
+    console.log(chalk.red('\n❌ No frameworks found\n'));
+    return;
+  }
+
+  const grouped = groupByLanguage(frameworks);
+
+  console.log(chalk.bold('\n📦 Available Frameworks:\n'));
+
+  Object.entries(grouped).forEach(([lang, list]) => {
+    console.log(chalk.cyan(`  ${lang.toUpperCase()}`));
+    list.forEach(f => console.log(formatFrameworkLine(f)));
+    console.log('');
+  });
+};
+
+module.exports = {
+  loadIndex,
+  getFrameworks,
+  findFramework,
+  searchFrameworks,
+  groupByLanguage,
+  validatePluginFiles,
+  loadPlugin,
+  formatFrameworkLine,
+  displayFrameworks,
+};

--- a/core/tests/registry.test.js
+++ b/core/tests/registry.test.js
@@ -1,0 +1,175 @@
+const path = require('path');
+const {
+  loadIndex,
+  getFrameworks,
+  findFramework,
+  searchFrameworks,
+  groupByLanguage,
+  validatePluginFiles,
+  formatFrameworkLine,
+} = require('../registry');
+
+describe('loadIndex()', () => {
+  test('loads index.json successfully', () => {
+    const result = loadIndex();
+    expect(result).not.toBeNull();
+    expect(result).toHaveProperty('frameworks');
+  });
+
+  test('returns null for invalid json', () => {
+    const result = loadIndex();
+    expect(typeof result).toBe('object');
+  });
+});
+
+describe('getFrameworks()', () => {
+  test('returns array of frameworks', () => {
+    const result = getFrameworks();
+    expect(Array.isArray(result)).toBe(true);
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  test('each framework has required fields', () => {
+    const frameworks = getFrameworks();
+    frameworks.forEach(f => {
+      expect(f).toHaveProperty('name');
+      expect(f).toHaveProperty('alias');
+      expect(f).toHaveProperty('language');
+      expect(f).toHaveProperty('latest');
+      expect(f).toHaveProperty('versions');
+      expect(f).toHaveProperty('path');
+    });
+  });
+});
+
+describe('findFramework()', () => {
+  test('finds framework by exact name', () => {
+    const result = findFramework('Laravel');
+    expect(result).not.toBeNull();
+    expect(result.name).toBe('Laravel');
+  });
+
+  test('finds framework by alias', () => {
+    const result = findFramework('nestjs');
+    expect(result).not.toBeNull();
+    expect(result.name).toBe('NestJS');
+  });
+
+  test('is case insensitive', () => {
+    const result = findFramework('LARAVEL');
+    expect(result).not.toBeNull();
+    expect(result.name).toBe('Laravel');
+  });
+
+  test('returns null for unknown framework', () => {
+    const result = findFramework('unknownxyz');
+    expect(result).toBeNull();
+  });
+
+  test('finds framework by partial alias', () => {
+    const result = findFramework('vue');
+    expect(result).not.toBeNull();
+    expect(result.name).toBe('VueJS');
+  });
+});
+
+describe('searchFrameworks()', () => {
+  test('finds frameworks by partial name', () => {
+    const results = searchFrameworks('nest');
+    expect(results.length).toBeGreaterThan(0);
+  });
+
+  test('finds frameworks by language', () => {
+    const results = searchFrameworks('php');
+    expect(results.length).toBeGreaterThan(0);
+    results.forEach(f => {
+      expect(f.language).toBe('php');
+    });
+  });
+
+  test('returns empty array for no match', () => {
+    const results = searchFrameworks('xyzunknown');
+    expect(results).toHaveLength(0);
+  });
+
+  test('finds multiple frameworks in same language', () => {
+    const results = searchFrameworks('javascript');
+    expect(results.length).toBeGreaterThan(1);
+  });
+});
+
+describe('groupByLanguage()', () => {
+  test('groups frameworks correctly', () => {
+    const frameworks = [
+      {
+        name: 'Laravel',
+        language: 'php',
+        alias: [],
+        latest: 'v11',
+        versions: ['v11'],
+        path: 'php/laravel',
+      },
+      {
+        name: 'Symfony',
+        language: 'php',
+        alias: [],
+        latest: 'v7',
+        versions: ['v7'],
+        path: 'php/symfony',
+      },
+      {
+        name: 'NestJS',
+        language: 'javascript',
+        alias: [],
+        latest: 'v10',
+        versions: ['v10'],
+        path: 'javascript/nestjs',
+      },
+    ];
+
+    const result = groupByLanguage(frameworks);
+
+    expect(result).toHaveProperty('php');
+    expect(result).toHaveProperty('javascript');
+    expect(result.php).toHaveLength(2);
+    expect(result.javascript).toHaveLength(1);
+  });
+
+  test('returns empty object for empty array', () => {
+    const result = groupByLanguage([]);
+    expect(result).toEqual({});
+  });
+});
+
+describe('validatePluginFiles()', () => {
+  test('returns invalid for non existent plugin path', () => {
+    const result = validatePluginFiles('/non/existent/path', 'v11');
+    expect(result.valid).toBe(false);
+    expect(result.missing.length).toBeGreaterThan(0);
+  });
+});
+
+describe('formatFrameworkLine()', () => {
+  test('formats framework line correctly', () => {
+    const framework = {
+      name: 'Laravel',
+      alias: ['laravel'],
+      latest: 'v11',
+    };
+    const result = formatFrameworkLine(framework);
+    expect(result).toContain('Laravel');
+    expect(result).toContain('laravel');
+    expect(result).toContain('v11');
+  });
+
+  test('handles multiple aliases', () => {
+    const framework = {
+      name: 'NestJS',
+      alias: ['nestjs', 'nest'],
+      latest: 'v10',
+    };
+    const result = formatFrameworkLine(framework);
+    expect(result).toContain('nestjs');
+    expect(result).toContain('nest');
+  });
+});


### PR DESCRIPTION
## 📋 Description
Builds the registry engine in functional programming style. Loads and manages all framework plugins from registry/index.json, supports exact name lookup, fuzzy search, language filtering, and plugin file validation before loading.

## 🔗 Related Issue
Closes #11

## 🔄 Type of Change
- [ ] feat (new feature)

## ✅ Acceptance Criteria
- [x] Reads registry/index.json correctly
- [x] Finds framework by name or alias
- [x] Fuzzy search works
- [x] Groups frameworks by language
- [x] Validates plugin files before loading
- [x] Written in functional programming style
- [x] Unit tests written and passing

## 🧪 How To Test
1. Pull this branch
2. Run npm test
3. Verify all registry tests pass

## 📊 Checklist
- [x] Branch is up to date with develop
- [x] Linked to correct milestone