### PR TITLE
feat: #30 build utils.js shared helpers

### DIFF
--- a/core/tests/utils.test.js
+++ b/core/tests/utils.test.js
@@ -1,0 +1,156 @@
+const {
+  log,
+  success,
+  warn,
+  error,
+  title,
+  divider,
+  step,
+  buildPluginUtils,
+} = require('../utils');
+
+// ─── Silence console output during tests ──────────────
+beforeEach(() => {
+  jest.spyOn(console, 'log').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+// ─── log() ────────────────────────────────────────────
+describe('log()', () => {
+  test('calls console.log', () => {
+    log('test message');
+    expect(console.log).toHaveBeenCalledTimes(1);
+  });
+
+  test('includes message in output', () => {
+    log('hello world');
+    const output = console.log.mock.calls[0][0];
+    expect(output).toContain('hello world');
+  });
+});
+
+// ─── success() ────────────────────────────────────────
+describe('success()', () => {
+  test('calls console.log', () => {
+    success('it worked!');
+    expect(console.log).toHaveBeenCalledTimes(1);
+  });
+
+  test('includes message in output', () => {
+    success('project created');
+    const output = console.log.mock.calls[0][0];
+    expect(output).toContain('project created');
+  });
+});
+
+// ─── warn() ───────────────────────────────────────────
+describe('warn()', () => {
+  test('calls console.log', () => {
+    warn('something is off');
+    expect(console.log).toHaveBeenCalledTimes(1);
+  });
+
+  test('includes message in output', () => {
+    warn('missing optional tool');
+    const output = console.log.mock.calls[0][0];
+    expect(output).toContain('missing optional tool');
+  });
+});
+
+// ─── error() ──────────────────────────────────────────
+describe('error()', () => {
+  test('calls console.log', () => {
+    error('something broke');
+    expect(console.log).toHaveBeenCalledTimes(1);
+  });
+
+  test('includes message in output', () => {
+    error('command failed');
+    const output = console.log.mock.calls[0][0];
+    expect(output).toContain('command failed');
+  });
+});
+
+// ─── title() ──────────────────────────────────────────
+describe('title()', () => {
+  test('calls console.log', () => {
+    title('Setting Up Project');
+    expect(console.log).toHaveBeenCalledTimes(1);
+  });
+
+  test('includes message in output', () => {
+    title('Setting Up Project');
+    const output = console.log.mock.calls[0][0];
+    expect(output).toContain('Setting Up Project');
+  });
+});
+
+// ─── divider() ────────────────────────────────────────
+describe('divider()', () => {
+  test('calls console.log', () => {
+    divider();
+    expect(console.log).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ─── step() ───────────────────────────────────────────
+describe('step()', () => {
+  test('calls console.log', () => {
+    step(1, 'Installing dependencies');
+    expect(console.log).toHaveBeenCalledTimes(1);
+  });
+
+  test('includes step number in output', () => {
+    step(3, 'Configuring database');
+    const output = console.log.mock.calls[0][0];
+    expect(output).toContain('3');
+  });
+
+  test('includes message in output', () => {
+    step(1, 'Installing dependencies');
+    const output = console.log.mock.calls[0][0];
+    expect(output).toContain('Installing dependencies');
+  });
+});
+
+// ─── buildPluginUtils() ───────────────────────────────
+describe('buildPluginUtils()', () => {
+  const mockExecutor = {
+    run: jest.fn(),
+    runInProject: jest.fn(),
+    setEnv: jest.fn(),
+    appendToFile: jest.fn(),
+    createFile: jest.fn(),
+  };
+
+  test('returns object with all executor methods', () => {
+    const utils = buildPluginUtils(mockExecutor);
+    expect(utils).toHaveProperty('run');
+    expect(utils).toHaveProperty('runInProject');
+    expect(utils).toHaveProperty('setEnv');
+    expect(utils).toHaveProperty('appendToFile');
+    expect(utils).toHaveProperty('createFile');
+  });
+
+  test('returns object with all util methods', () => {
+    const utils = buildPluginUtils(mockExecutor);
+    expect(utils).toHaveProperty('log');
+    expect(utils).toHaveProperty('success');
+    expect(utils).toHaveProperty('warn');
+    expect(utils).toHaveProperty('error');
+    expect(utils).toHaveProperty('step');
+  });
+
+  test('run points to executor.run', () => {
+    const utils = buildPluginUtils(mockExecutor);
+    expect(utils.run).toBe(mockExecutor.run);
+  });
+
+  test('log is a function', () => {
+    const utils = buildPluginUtils(mockExecutor);
+    expect(typeof utils.log).toBe('function');
+  });
+});

--- a/core/utils.js
+++ b/core/utils.js
@@ -1,2 +1,61 @@
-// TODO: Coming in Sprint 1
-module.exports = {};
+const chalk = require('chalk');
+
+const log = message => {
+  console.log(chalk.white(`  ${message}`));
+};
+
+// ─── Success Message ───────────────────────────────────
+const success = message => {
+  console.log(chalk.green(`\n  ${message}\n`));
+};
+
+// ─── Warning Message ───────────────────────────────────
+const warn = message => {
+  console.log(chalk.yellow(`  ⚠️  ${message}`));
+};
+
+// ─── Error Message ─────────────────────────────────────
+const error = message => {
+  console.log(chalk.red(`  ❌ ${message}`));
+};
+
+// ─── Section Title ─────────────────────────────────────
+const title = message => {
+  console.log(chalk.cyan.bold(`\n  ── ${message} ──\n`));
+};
+
+// ─── Divider Line ──────────────────────────────────────
+const divider = () => {
+  console.log(chalk.gray('  ──────────────────────────────────────────'));
+};
+
+// ─── Step Indicator ────────────────────────────────────
+const step = (number, message) => {
+  console.log(chalk.cyan(`  [${number}]`) + chalk.white(` ${message}`));
+};
+
+// ─── Build Utils Object For Plugins ───────────────────
+const buildPluginUtils = executor => ({
+  run: executor.run,
+  runInProject: executor.runInProject,
+  setEnv: executor.setEnv,
+  appendToFile: executor.appendToFile,
+  createFile: executor.createFile,
+  log,
+  success,
+  warn,
+  error,
+  step,
+});
+
+// ─── Exports ───────────────────────────────────────────
+module.exports = {
+  log,
+  success,
+  warn,
+  error,
+  title,
+  divider,
+  step,
+  buildPluginUtils,
+};


### PR DESCRIPTION
## 📋 Description
Builds shared utility functions for terminal output formatting and the buildPluginUtils factory that combines executor and utils into a single clean API passed to every scaffold.js plugin.

## 🔗 Related Issue
Closes #30 

## 🔄 Type of Change
- [x] feat (new feature)

## ✅ Acceptance Criteria
- [x] log() prints info message
- [x] success() prints green success
- [x] warn() prints yellow warning
- [x] error() prints red error
- [x] title() prints section header
- [x] divider() prints separator line
- [x] step() prints numbered step
- [x] buildPluginUtils() combines executor and utils
- [x] Unit tests written and passing

## 🧪 How To Test
1. Pull this branch
2. Run npm test
3. Verify all 16 utils tests pass

## 📊 Checklist
- [x] Branch is up to date with develop
- [x] Linked to correct milestone